### PR TITLE
Title bar drags don't call nvim.input_mouse()

### DIFF
--- a/src/NVWindowController.mm
+++ b/src/NVWindowController.mm
@@ -804,6 +804,9 @@ static inline bool pointInGrid(nvim::grid_point point, nvim::grid_size size) {
     }
 
     NSPoint windowLocation = [event locationInWindow];
+    if (!NSPointInRect(windowLocation, self.window.contentLayoutRect)) {
+        return;
+    }
     nvim::grid_point location = [gridView cellLocation:windowLocation clampTo:lastGridSize];
     nvim::grid_point &lastLocation = lastMouseLocation[button];
 


### PR DESCRIPTION
Erroneous nvim.input_mouse() calls would take you out of insert mode in terminal emulator when trying to drag the title bar.