### PR TITLE
Handle busy_start and busy_end events

### DIFF
--- a/src/NVGridView.mm
+++ b/src/NVGridView.mm
@@ -327,6 +327,11 @@ static void blinkCursorToggleOn(void *context);
         return;
     }
 
+    if (grid->hide_cursor()) {
+        cursor.toggle_off();
+        return;
+    }
+
     if (cursor.blinks()) {
         auto time = dispatch_time(DISPATCH_TIME_NOW, cursor.blinkwait() * NSEC_PER_MSEC);
 
@@ -386,7 +391,9 @@ static void blinkCursorToggleOff(void *context) {
 static void blinkCursorToggleOn(void *context) {
     NVGridView *self = (__bridge NVGridView*)context;
 
-    self->cursor.toggle_on();
+    if (!self.grid->hide_cursor()) {
+        self->cursor.toggle_on();
+    }
     [self setNeedsDisplay:YES];
 
     auto time = dispatch_time(DISPATCH_TIME_NOW, self->cursor.blinkon() * NSEC_PER_MSEC);

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -185,6 +185,10 @@ void ui_controller::redraw_event(const msg::object &event_object) {
         return apply(this, &ui_controller::tabline_update, name, args);
     } else if (name == "set_title") {
         return apply(this, &ui_controller::set_title, name, args);
+    } else if (name == "busy_start") {
+        return apply(this, &ui_controller::busy_start, name, args);
+    } else if (name == "busy_stop") {
+        return apply(this, &ui_controller::busy_stop, name, args);
     }
 
     // When options change, we should inform the delegate. Neovim tends to
@@ -397,6 +401,14 @@ void ui_controller::grid_scroll(size_t grid_id, size_t top, size_t bottom,
         dest += row_width;
         src += row_width;
     }
+}
+
+void ui_controller::busy_start() {
+    writing->cursor_hidden = true;
+}
+
+void ui_controller::busy_stop() {
+    writing->cursor_hidden = false;
 }
 
 void ui_controller::flush() {

--- a/src/ui.hpp
+++ b/src/ui.hpp
@@ -442,11 +442,12 @@ private:
     size_t cursor_row;
     size_t cursor_col;
     uint64_t draw_tick;
+    bool cursor_hidden;
 
     friend class ui_controller;
 
 public:
-    grid(): grid_width(0), grid_height(0), draw_tick(0) {}
+    grid(): grid_width(0), grid_height(0), draw_tick(0), cursor_hidden(0) {}
 
     const cell* begin() const {
         return cells.data();
@@ -464,6 +465,11 @@ public:
     /// A const pointer to the cell at the given row and column position.
     const cell* get(size_t row, size_t col) const {
         return cells.data() + (row * grid_width) + col;
+    }
+    
+    /// Return whether to hide cursor.
+    bool hide_cursor() const {
+        return cursor_hidden;
     }
 
     /// Returns the grid's cursor.
@@ -615,6 +621,10 @@ private:
     void redraw_event(const msg::object &event);
 
     void flush();
+    
+    void busy_start();
+    
+    void busy_stop();
 
     void grid_resize(size_t grid, size_t width, size_t height);
 


### PR DESCRIPTION
These oddly named events hide the cursor when the terminal window is used. Without this, the terminal shows 2 cursors.